### PR TITLE
Fix bug for string -> int with comma delimters

### DIFF
--- a/tamago/__init__.py
+++ b/tamago/__init__.py
@@ -1,5 +1,5 @@
 """
 init - version info
 """
-VERSION_INFO = (1, 1, 0)
+VERSION_INFO = (1, 1, 1)
 VERSION = '.'.join(str(c) for c in VERSION_INFO)

--- a/tamago/lib/plugins/apex.py
+++ b/tamago/lib/plugins/apex.py
@@ -49,6 +49,7 @@ LEGENDS = [
 
 
 def rank_lookup(value, ranges):
+    value = utils.to_int(value)
     left, right = 0, len(ranges)
     while left != right - 1:
         mid = left + (right - left) // 2

--- a/tamago/lib/utils.py
+++ b/tamago/lib/utils.py
@@ -11,6 +11,16 @@ from discord.ext import commands
 LOG = logging.getLogger(__name__)
 BLOCKED_USERS = os.getenv('BLOCKED_USERS') or '123456'
 
+
+
+
+def to_int(value):
+    if isinstance(value, str):
+        return int(value.replace(",", ""))
+    else:
+        return value
+
+
 def parse_arguments():
     """parsing arguments.
 


### PR DESCRIPTION
# What? 

Fixes minor bug for rankscores in apex bot larger to 999, cause comma delimiter issue when converting a string to int. 